### PR TITLE
Update to 2.53.1

### DIFF
--- a/selenium-server-standalone-current.jar
+++ b/selenium-server-standalone-current.jar
@@ -1,0 +1,1 @@
+selenium-server-standalone-2.53.1.jar


### PR DESCRIPTION
Updates our composer to 2.53.1, also provides a symlink to the jar as `selenium-standalone-server-current.jar`, so we aren't tied to the version externally.